### PR TITLE
change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14-slim
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
if use `node:14` image and the build image size is 1000+ MB

and change `node:14` to `node:14-slim` the build image size was 339MB